### PR TITLE
Compatibility with React v15.5+

### DIFF
--- a/Pagination.js
+++ b/Pagination.js
@@ -1,4 +1,5 @@
-import React, { findDOMNode, Component, PropTypes } from 'react';
+import React, { findDOMNode, Component } from 'react';
+import PropTypes from "prop-types";
 
 export default class Pagination extends Component {
   render() {


### PR DESCRIPTION
 Install the prop-types package and import `PropTypes` from there.

https://reactjs.org/blog/2017/04/07/react-v15.5.0.html